### PR TITLE
Get Cocoa pods to work with standard project Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This module exposes the native iOS APIs to ask the user to rate the app in the i
 Add the following to your `Podfile` and run `pod install`:
 
 ```ruby
-pod 'RNStoreReview', :path => 'node_modules/react-native-store-review/ios'
+pod 'RNStoreReview', :path => '../node_modules/react-native-store-review/ios'
 ```
 
 ## Usage

--- a/ios/RNStoreReview.podspec
+++ b/ios/RNStoreReview.podspec
@@ -1,5 +1,5 @@
 require "json"
-version = JSON.parse(File.read("package.json"))["version"]
+version = JSON.parse(File.read("../package.json"))["version"]
 
 Pod::Spec.new do |s|
   s.name           = "RNStoreReview"


### PR DESCRIPTION
Stadard project Structure is an ios folder that is the working path for ios build command. I had to do this to get the build to work.

Cheers
Anders