### PR TITLE
Added requiresMainQueueSetup

### DIFF
--- a/ios/RNStoreReview.m
+++ b/ios/RNStoreReview.m
@@ -22,4 +22,9 @@ RCT_EXPORT_METHOD(requestReview)
   [SKStoreReviewController requestReview];
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 @end


### PR DESCRIPTION
Added requiresMainQueueSetup to prevent warning and future side-effects in RNStoreReview.