### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/ios/RNStoreReview.podspec
+++ b/ios/RNStoreReview.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = "**/*.js"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
 
 end
 


### PR DESCRIPTION
Latest Xcode 12 fails to build without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116