### PR TITLE
chore: replacing play:core with play:review

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,13 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: 'com.android.library'
+
+def DEFAULT_CORE_APP_REVIEW_VERSION = "2.0.1"
+
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 if (isNewArchitectureEnabled()) {
     apply plugin: 'com.facebook.react'
 }
@@ -50,5 +57,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.google.android.play:core:1.10.3'
+  implementation("com.google.android.play:review:${safeExtGet('playCoreReviewVersion', DEFAULT_CORE_APP_REVIEW_VERSION)}")
 }

--- a/android/src/main/java/com/oblador/storereview/StoreReviewModuleImpl.java
+++ b/android/src/main/java/com/oblador/storereview/StoreReviewModuleImpl.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import com.google.android.play.core.review.ReviewManager;
 import com.google.android.play.core.review.ReviewManagerFactory;
 import com.google.android.play.core.review.ReviewInfo;
-import com.google.android.play.core.tasks.Task;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.google.android.gms.tasks.Task;
 
 public class StoreReviewModuleImpl {
 


### PR DESCRIPTION
Google is moving away from a single `com.google.android.play:core` package, and instead it’s splitting functionality [into multiple packages](https://developer.android.com/guide/playcore#playcore-migration).

This project only needs the `com.google.android.play:review` package.

This PR does exactly that, it replaces the generic library with the specific one it does need.
(Also it allows the play:review version to be changed by the parent project if needed).