### PR TITLE
Log exception when requesting a review fails on Android

### DIFF
--- a/android/src/main/java/com/oblador/storereview/StoreReviewModuleImpl.java
+++ b/android/src/main/java/com/oblador/storereview/StoreReviewModuleImpl.java
@@ -22,7 +22,7 @@ public class StoreReviewModuleImpl {
                 ReviewInfo reviewInfo = task.getResult();
                 manager.launchReviewFlow(context.getCurrentActivity(), reviewInfo);
             } else {
-                Log.w(NAME, "Requesting review failed");
+                Log.w(NAME, "Requesting review failed", task.getException());
             }
         });
     }


### PR DESCRIPTION
This is just a small change that _should_ make debugging easier when things fall apart on Android. [`Log.w`](https://developer.android.com/reference/android/util/Log#w(java.lang.String,%20java.lang.String,%20java.lang.Throwable)) takes a nullable `Throwable` argument after the `msg`. Information about that exception will be included in the log output.

For example:

```
Requesting review failed
com.google.android.play.core.review.internal.zzu: Failed to bind to the service.
```

---

I needed this to understand why the review prompt wasn't showing (turns out it's because my emulator doesn't have Google Play installed) and I hope this can help others in the future!!