### PR TITLE
refactor: add AppStore requestReview method, replace deprecated SKStoreReviewController

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-store-review
 
-This module exposes the native APIs to ask the user to rate the app in the iOS App Store or Google Play store directly from within the app (requires iOS >= 12.4 or Android 5.0 with Google Play store installed). 
+This module exposes the native APIs to ask the user to rate the app in the iOS App Store or Google Play store directly from within the app (requires iOS >= 14.0 or Android 5.0 with Google Play store installed). 
 
 <img width="274" alt="Rating Dialog" src="https://cloud.githubusercontent.com/assets/378279/24377493/d22eb0b8-133f-11e7-9968-44d186a3801f.png">
 

--- a/RNStoreReview.podspec
+++ b/RNStoreReview.podspec
@@ -8,9 +8,9 @@ Pod::Spec.new do |s|
   s.homepage       = "https://github.com/oblador/react-native-store-review"
   s.license        = "MIT"
   s.author         = { "Joel Arvidsson" => "joel@oblador.se" }
-  s.platform       = :ios, "12.4"
+  s.platform       = :ios, "14.0"
   s.source         = { :git => "https://github.com/oblador/react-native-store-review.git", :tag => "v#{s.version}" }
-  s.source_files   = "ios/*.{h,m,mm}"
+  s.source_files   = "ios/*.{h,m,mm,swift}"
   s.preserve_paths = "**/*.js"
   s.ios.framework  = 'StoreKit'
   s.requires_arc = true

--- a/ios/RNStoreReview.h
+++ b/ios/RNStoreReview.h
@@ -1,6 +1,15 @@
 #import <Foundation/Foundation.h>
-#import <React/RCTBridgeModule.h>
 
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import <RNStoreReviewSpec/RNStoreReviewSpec.h>
+@interface RNStoreReview: NSObject <NativeRNStoreReviewSpec>
+
+#else
+
+#import <React/RCTBridgeModule.h>
 @interface RNStoreReview : NSObject <RCTBridgeModule>
+
+#endif
 
 @end

--- a/ios/RNStoreReview.mm
+++ b/ios/RNStoreReview.mm
@@ -1,9 +1,6 @@
 #import "RNStoreReview.h"
-#import <StoreKit/SKStoreReviewController.h>
 
-#ifdef RCT_NEW_ARCH_ENABLED
-#import <RNStoreReviewSpec/RNStoreReviewSpec.h>
-#endif
+#import "RNStoreReview-Swift.h"
 
 @implementation RNStoreReview
 
@@ -16,21 +13,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(requestReview)
 {
-  if (@available(iOS 14.0, *)) {
-    UIWindowScene *activeScene;
-    NSSet *scenes = [[UIApplication sharedApplication] connectedScenes];
-    for (UIScene *scene in scenes) {
-      if ([scene activationState] == UISceneActivationStateForegroundActive) {
-        activeScene = scene;
-        break;
-      }
-    }
-    if (activeScene != nil) {
-      [SKStoreReviewController requestReviewInScene:activeScene];
-    }
-  } else {
-    [SKStoreReviewController requestReview];
-  }
+  [StoreReview requestReview];
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/StoreReview.swift
+++ b/ios/StoreReview.swift
@@ -1,0 +1,18 @@
+import Foundation
+import StoreKit
+
+@objc
+public class StoreReview: NSObject {
+
+  @MainActor
+  @objc
+  public static func requestReview() {
+    if let activeScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+      if #available(iOS 16.0, *) {
+        AppStore.requestReview(in: activeScene)
+      } else {
+        SKStoreReviewController.requestReview(in: activeScene)
+      }
+    }
+  }
+}


### PR DESCRIPTION
`SKStoreReviewController requestReview` became deprecated as of iOS18.0.
This PR adds the AppStore requestReview method, which was introduced in iOS16.0.

I also added a commit to update the example to the latest react-native 0.77 and slightly improved the new arch code.

PS. `AppStore.requestReview` is only available in Swift, therefore StoreReview.swift is introduced.